### PR TITLE
fixed XAPID-1040

### DIFF
--- a/api.go
+++ b/api.go
@@ -16,6 +16,7 @@ package apiGatewayConfDeploy
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"github.com/gorilla/mux"
 	"io"
 	"io/ioutil"
@@ -302,7 +303,7 @@ func (a *apiManager) sendReadyDeployments(w http.ResponseWriter) {
 	eTag := a.getETag()
 	deployments, err := a.dbMan.getReadyDeployments()
 	if err != nil {
-		a.writeInternalError(w, "Database error")
+		a.writeInternalError(w, fmt.Sprintf("Database error: %s", err.Error()))
 		return
 	}
 	a.sendDeployments(w, deployments, eTag)

--- a/data.go
+++ b/data.go
@@ -192,11 +192,7 @@ func (dbc *dbManager) getReadyDeployments() ([]DataDeployment, error) {
 
 	log.Debugf("Configurations ready: %v", deployments)
 
-	if len(deployments) == 0 {
-		log.Debug("No resources ready to be deployed")
-		err = sql.ErrNoRows
-	}
-	return deployments, err
+	return deployments, nil
 
 }
 

--- a/data_test.go
+++ b/data_test.go
@@ -88,6 +88,12 @@ var _ = Describe("data", func() {
 			Expect(count).Should(Equal(3))
 		})
 
+		It("should get empty slice if no deployments are ready", func() {
+			deps, err := testDbMan.getReadyDeployments()
+			Expect(err).Should(Succeed())
+			Expect(len(deps)).Should(BeZero())
+		})
+
 		It("should succefully update local FS location", func() {
 
 			err := testDbMan.updateLocalFsLocation(readyBlobId, readyblobLocalFs)


### PR DESCRIPTION
After the fix, if there are no ready configs, the response is like:
{
  "kind": "Collection",
  "self": "http://localhost:9099/configurations",
  "contents": []
}